### PR TITLE
Revert "Adjust the dropdown form helper override"

### DIFF
--- a/application/helpers/MY_form_helper.php
+++ b/application/helpers/MY_form_helper.php
@@ -81,8 +81,8 @@ if ( ! function_exists('form_dropdown'))
 			}
 			else
 			{
-				$form .= '<option value="'.html_escape($val).'"'
-					.(in_array($val, $selected) ? ' selected="selected"' : '').'>'
+				$form .= '<option value="'.html_escape($key).'"'
+					.(in_array($key, $selected) ? ' selected="selected"' : '').'>'
 					.(string) $val."</option>\n";
 			}
 		}


### PR DESCRIPTION
This reverts commit 41df08496062a26bd6e78754ad0a2d79d884c012.

Changes from origional commit makes all dropdowns where key is different
from value not work properly.

Undoing this not well-documented change makes them work as expected
again (including the band selection dropdown)